### PR TITLE
Updated .travis.yml to support tests for go 1.6, removed support for go 1.4.3 in tests, removed getting of go vet from test script

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ It's used in the [snap framework](http://github.com:intelsdi-x/snap).
 
 ## Getting Started
 ### System Requirements
-* [golang 1.4+](https://golang.org/dl/)
+* [golang 1.5+](https://golang.org/dl/) (needed only for building)
 
 ### Operating systems
 All OSs currently supported by snap:


### PR DESCRIPTION
Supported golang in .travis.yml has been updated.
Removed go vet import because of this [commit](https://github.com/golang/tools/commit/adaaa074861b0d254acf51dec74daf7c2ba20e90), without updating test.sh it is not possible to successfully execute tests.